### PR TITLE
propagate IDs in controllers

### DIFF
--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load all the prometheus client-go plugin
 	_ "k8s.io/component-base/metrics/prometheus/version"  // for version metric registration
+	"k8s.io/component-base/traces"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app"
 )
 
@@ -43,6 +44,8 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
+	// TODO: initTraces only if feature gate ObjectTraceIDs is enabled
+	traces.InitTraces("kube-controller-manage")
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -453,7 +453,7 @@ type PodControlInterface interface {
 	// and sets the ControllerRef.
 	CreatePodsOnNode(nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error
 	// CreatePodsWithControllerRef creates new pods according to the spec, and sets object as the pod's controller.
-	CreatePodsWithControllerRef(namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error
+	CreatePodsWithControllerRef(ctx context.Context, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error
 	// DeletePod deletes the pod identified by podID.
 	DeletePod(namespace string, podID string, object runtime.Object) error
 	// PatchPod patches the pod.
@@ -519,21 +519,21 @@ func validateControllerRef(controllerRef *metav1.OwnerReference) error {
 }
 
 func (r RealPodControl) CreatePods(namespace string, template *v1.PodTemplateSpec, object runtime.Object) error {
-	return r.createPods("", namespace, template, object, nil)
+	return r.createPods(context.Background(), "", namespace, template, object, nil)
 }
 
-func (r RealPodControl) CreatePodsWithControllerRef(namespace string, template *v1.PodTemplateSpec, controllerObject runtime.Object, controllerRef *metav1.OwnerReference) error {
+func (r RealPodControl) CreatePodsWithControllerRef(ctx context.Context, namespace string, template *v1.PodTemplateSpec, controllerObject runtime.Object, controllerRef *metav1.OwnerReference) error {
 	if err := validateControllerRef(controllerRef); err != nil {
 		return err
 	}
-	return r.createPods("", namespace, template, controllerObject, controllerRef)
+	return r.createPods(ctx, "", namespace, template, controllerObject, controllerRef)
 }
 
 func (r RealPodControl) CreatePodsOnNode(nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
 	if err := validateControllerRef(controllerRef); err != nil {
 		return err
 	}
-	return r.createPods(nodeName, namespace, template, object, controllerRef)
+	return r.createPods(context.Background(), nodeName, namespace, template, object, controllerRef)
 }
 
 func (r RealPodControl) PatchPod(namespace, name string, data []byte) error {
@@ -566,7 +566,7 @@ func GetPodFromTemplate(template *v1.PodTemplateSpec, parentObject runtime.Objec
 	return pod, nil
 }
 
-func (r RealPodControl) createPods(nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
+func (r RealPodControl) createPods(ctx context.Context, nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
 	pod, err := GetPodFromTemplate(template, object, controllerRef)
 	if err != nil {
 		return err
@@ -577,7 +577,7 @@ func (r RealPodControl) createPods(nodeName, namespace string, template *v1.PodT
 	if len(labels.Set(pod.Labels)) == 0 {
 		return fmt.Errorf("unable to create pods, no labels")
 	}
-	newPod, err := r.KubeClient.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	newPod, err := r.KubeClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		// only send an event if the namespace isn't terminating
 		if !apierrors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
@@ -652,7 +652,7 @@ func (f *FakePodControl) CreatePods(namespace string, spec *v1.PodTemplateSpec, 
 	return nil
 }
 
-func (f *FakePodControl) CreatePodsWithControllerRef(namespace string, spec *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
+func (f *FakePodControl) CreatePodsWithControllerRef(ctx context.Context, namespace string, spec *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
 	f.Lock()
 	defer f.Unlock()
 	f.CreateCallCount++

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -968,7 +968,7 @@ func (dsc *DaemonSetsController) syncNodes(ds *apps.DaemonSet, podsToDelete, nod
 				podTemplate.Spec.Affinity = util.ReplaceDaemonSetPodNodeNameNodeAffinity(
 					podTemplate.Spec.Affinity, nodesNeedingDaemonPods[ix])
 
-				err := dsc.podControl.CreatePodsWithControllerRef(ds.Namespace, podTemplate,
+				err := dsc.podControl.CreatePodsWithControllerRef(context.Background(), ds.Namespace, podTemplate,
 					ds, metav1.NewControllerRef(ds, controllerKind))
 
 				if err != nil {

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -267,10 +267,10 @@ func (f *fakePodControl) CreatePodsOnNode(nodeName, namespace string, template *
 	return nil
 }
 
-func (f *fakePodControl) CreatePodsWithControllerRef(namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
+func (f *fakePodControl) CreatePodsWithControllerRef(ctx context.Context, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
 	f.Lock()
 	defer f.Unlock()
-	if err := f.FakePodControl.CreatePodsWithControllerRef(namespace, template, object, controllerRef); err != nil {
+	if err := f.FakePodControl.CreatePodsWithControllerRef(context.Background(), namespace, template, object, controllerRef); err != nil {
 		return fmt.Errorf("failed to create pod for DaemonSet")
 	}
 

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -24,12 +24,13 @@ import (
 	"strconv"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
+	"k8s.io/kubernetes/pkg/util/httptrace"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 )
 
@@ -72,6 +73,9 @@ func (dc *DeploymentController) sync(d *apps.Deployment, rsList []*apps.ReplicaS
 // These conditions are needed so that we won't accidentally report lack of progress for resumed deployments
 // that were paused for longer than progressDeadlineSeconds.
 func (dc *DeploymentController) checkPausedConditions(d *apps.Deployment) error {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), d.GetAnnotations())
+
 	if !deploymentutil.HasProgressDeadline(d) {
 		return nil
 	}
@@ -98,7 +102,7 @@ func (dc *DeploymentController) checkPausedConditions(d *apps.Deployment) error 
 	}
 
 	var err error
-	_, err = dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(context.TODO(), d, metav1.UpdateOptions{})
+	_, err = dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(ctx, d, metav1.UpdateOptions{})
 	return err
 }
 
@@ -136,6 +140,9 @@ const (
 // 3. If there's no existing new RS and createIfNotExisted is true, create one with appropriate revision number (maxOldRevision + 1) and replicas.
 // Note that the pod-template-hash will be added to adopted RSes and pods.
 func (dc *DeploymentController) getNewReplicaSet(d *apps.Deployment, rsList, oldRSs []*apps.ReplicaSet, createIfNotExisted bool) (*apps.ReplicaSet, error) {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), d.GetAnnotations())
+
 	existingNewRS := deploymentutil.FindNewReplicaSet(d, rsList)
 
 	// Calculate the max revision number among all old RSes
@@ -155,7 +162,7 @@ func (dc *DeploymentController) getNewReplicaSet(d *apps.Deployment, rsList, old
 		minReadySecondsNeedsUpdate := rsCopy.Spec.MinReadySeconds != d.Spec.MinReadySeconds
 		if annotationsUpdated || minReadySecondsNeedsUpdate {
 			rsCopy.Spec.MinReadySeconds = d.Spec.MinReadySeconds
-			return dc.client.AppsV1().ReplicaSets(rsCopy.ObjectMeta.Namespace).Update(context.TODO(), rsCopy, metav1.UpdateOptions{})
+			return dc.client.AppsV1().ReplicaSets(rsCopy.ObjectMeta.Namespace).Update(ctx, rsCopy, metav1.UpdateOptions{})
 		}
 
 		// Should use the revision in existingNewRS's annotation, since it set by before
@@ -173,7 +180,7 @@ func (dc *DeploymentController) getNewReplicaSet(d *apps.Deployment, rsList, old
 
 		if needsUpdate {
 			var err error
-			if _, err = dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(context.TODO(), d, metav1.UpdateOptions{}); err != nil {
+			if _, err = dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(ctx, d, metav1.UpdateOptions{}); err != nil {
 				return nil, err
 			}
 		}
@@ -220,7 +227,8 @@ func (dc *DeploymentController) getNewReplicaSet(d *apps.Deployment, rsList, old
 	// hash collisions. If there is any other error, we need to report it in the status of
 	// the Deployment.
 	alreadyExists := false
-	createdRS, err := dc.client.AppsV1().ReplicaSets(d.Namespace).Create(context.TODO(), &newRS, metav1.CreateOptions{})
+
+	createdRS, err := dc.client.AppsV1().ReplicaSets(d.Namespace).Create(ctx, &newRS, metav1.CreateOptions{})
 	switch {
 	// We may end up hitting this due to a slow cache or a fast resync of the Deployment.
 	case errors.IsAlreadyExists(err):
@@ -252,7 +260,7 @@ func (dc *DeploymentController) getNewReplicaSet(d *apps.Deployment, rsList, old
 		*d.Status.CollisionCount++
 		// Update the collisionCount for the Deployment and let it requeue by returning the original
 		// error.
-		_, dErr := dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(context.TODO(), d, metav1.UpdateOptions{})
+		_, dErr := dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(ctx, d, metav1.UpdateOptions{})
 		if dErr == nil {
 			klog.V(2).Infof("Found a hash collision for deployment %q - bumping collisionCount (%d->%d) to resolve it", d.Name, preCollisionCount, *d.Status.CollisionCount)
 		}
@@ -268,7 +276,7 @@ func (dc *DeploymentController) getNewReplicaSet(d *apps.Deployment, rsList, old
 			// We don't really care about this error at this point, since we have a bigger issue to report.
 			// TODO: Identify which errors are permanent and switch DeploymentIsFailed to take into account
 			// these reasons as well. Related issue: https://github.com/kubernetes/kubernetes/issues/18568
-			_, _ = dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(context.TODO(), d, metav1.UpdateOptions{})
+			_, _ = dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(ctx, d, metav1.UpdateOptions{})
 		}
 		dc.eventRecorder.Eventf(d, v1.EventTypeWarning, deploymentutil.FailedRSCreateReason, msg)
 		return nil, err
@@ -285,7 +293,7 @@ func (dc *DeploymentController) getNewReplicaSet(d *apps.Deployment, rsList, old
 		needsUpdate = true
 	}
 	if needsUpdate {
-		_, err = dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(context.TODO(), d, metav1.UpdateOptions{})
+		_, err = dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(ctx, d, metav1.UpdateOptions{})
 	}
 	return createdRS, err
 }
@@ -409,6 +417,8 @@ func (dc *DeploymentController) scaleReplicaSetAndRecordEvent(rs *apps.ReplicaSe
 }
 
 func (dc *DeploymentController) scaleReplicaSet(rs *apps.ReplicaSet, newScale int32, deployment *apps.Deployment, scalingOperation string) (bool, *apps.ReplicaSet, error) {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), rs.GetAnnotations())
 
 	sizeNeedsUpdate := *(rs.Spec.Replicas) != newScale
 
@@ -420,7 +430,7 @@ func (dc *DeploymentController) scaleReplicaSet(rs *apps.ReplicaSet, newScale in
 		rsCopy := rs.DeepCopy()
 		*(rsCopy.Spec.Replicas) = newScale
 		deploymentutil.SetReplicasAnnotations(rsCopy, *(deployment.Spec.Replicas), *(deployment.Spec.Replicas)+deploymentutil.MaxSurge(*deployment))
-		rs, err = dc.client.AppsV1().ReplicaSets(rsCopy.Namespace).Update(context.TODO(), rsCopy, metav1.UpdateOptions{})
+		rs, err = dc.client.AppsV1().ReplicaSets(rsCopy.Namespace).Update(ctx, rsCopy, metav1.UpdateOptions{})
 		if err == nil && sizeNeedsUpdate {
 			scaled = true
 			dc.eventRecorder.Eventf(deployment, v1.EventTypeNormal, "ScalingReplicaSet", "Scaled %s replica set %s to %d", scalingOperation, rs.Name, newScale)
@@ -433,6 +443,9 @@ func (dc *DeploymentController) scaleReplicaSet(rs *apps.ReplicaSet, newScale in
 // where N=d.Spec.RevisionHistoryLimit. Old replica sets are older versions of the podtemplate of a deployment kept
 // around by default 1) for historical reasons and 2) for the ability to rollback a deployment.
 func (dc *DeploymentController) cleanupDeployment(oldRSs []*apps.ReplicaSet, deployment *apps.Deployment) error {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), deployment.GetAnnotations())
+
 	if !deploymentutil.HasRevisionHistoryLimit(deployment) {
 		return nil
 	}
@@ -458,7 +471,7 @@ func (dc *DeploymentController) cleanupDeployment(oldRSs []*apps.ReplicaSet, dep
 			continue
 		}
 		klog.V(4).Infof("Trying to cleanup replica set %q for deployment %q", rs.Name, deployment.Name)
-		if err := dc.client.AppsV1().ReplicaSets(rs.Namespace).Delete(context.TODO(), rs.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		if err := dc.client.AppsV1().ReplicaSets(rs.Namespace).Delete(ctx, rs.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 			// Return error instead of aggregating and continuing DELETEs on the theory
 			// that we may be overloading the api server.
 			return err
@@ -470,6 +483,9 @@ func (dc *DeploymentController) cleanupDeployment(oldRSs []*apps.ReplicaSet, dep
 
 // syncDeploymentStatus checks if the status is up-to-date and sync it if necessary
 func (dc *DeploymentController) syncDeploymentStatus(allRSs []*apps.ReplicaSet, newRS *apps.ReplicaSet, d *apps.Deployment) error {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), d.GetAnnotations())
+
 	newStatus := calculateStatus(allRSs, newRS, d)
 
 	if reflect.DeepEqual(d.Status, newStatus) {
@@ -478,7 +494,7 @@ func (dc *DeploymentController) syncDeploymentStatus(allRSs []*apps.ReplicaSet, 
 
 	newDeployment := d
 	newDeployment.Status = newStatus
-	_, err := dc.client.AppsV1().Deployments(newDeployment.Namespace).UpdateStatus(context.TODO(), newDeployment, metav1.UpdateOptions{})
+	_, err := dc.client.AppsV1().Deployments(newDeployment.Namespace).UpdateStatus(ctx, newDeployment, metav1.UpdateOptions{})
 	return err
 }
 

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -74,7 +74,7 @@ func (dc *DeploymentController) sync(d *apps.Deployment, rsList []*apps.ReplicaS
 // that were paused for longer than progressDeadlineSeconds.
 func (dc *DeploymentController) checkPausedConditions(d *apps.Deployment) error {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), d.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), d)
 
 	if !deploymentutil.HasProgressDeadline(d) {
 		return nil
@@ -141,7 +141,7 @@ const (
 // Note that the pod-template-hash will be added to adopted RSes and pods.
 func (dc *DeploymentController) getNewReplicaSet(d *apps.Deployment, rsList, oldRSs []*apps.ReplicaSet, createIfNotExisted bool) (*apps.ReplicaSet, error) {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), d.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), d)
 
 	existingNewRS := deploymentutil.FindNewReplicaSet(d, rsList)
 
@@ -418,7 +418,7 @@ func (dc *DeploymentController) scaleReplicaSetAndRecordEvent(rs *apps.ReplicaSe
 
 func (dc *DeploymentController) scaleReplicaSet(rs *apps.ReplicaSet, newScale int32, deployment *apps.Deployment, scalingOperation string) (bool, *apps.ReplicaSet, error) {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), rs.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), rs)
 
 	sizeNeedsUpdate := *(rs.Spec.Replicas) != newScale
 
@@ -444,7 +444,7 @@ func (dc *DeploymentController) scaleReplicaSet(rs *apps.ReplicaSet, newScale in
 // around by default 1) for historical reasons and 2) for the ability to rollback a deployment.
 func (dc *DeploymentController) cleanupDeployment(oldRSs []*apps.ReplicaSet, deployment *apps.Deployment) error {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), deployment.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), deployment)
 
 	if !deploymentutil.HasRevisionHistoryLimit(deployment) {
 		return nil
@@ -483,8 +483,8 @@ func (dc *DeploymentController) cleanupDeployment(oldRSs []*apps.ReplicaSet, dep
 
 // syncDeploymentStatus checks if the status is up-to-date and sync it if necessary
 func (dc *DeploymentController) syncDeploymentStatus(allRSs []*apps.ReplicaSet, newRS *apps.ReplicaSet, d *apps.Deployment) error {
-	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), d.GetAnnotations())
+	// Get span and baggage from object and set to ctx
+	ctx := httptrace.SpanContextWithObject(context.Background(), d)
 
 	newStatus := calculateStatus(allRSs, newRS, d)
 

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	batch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -776,7 +776,7 @@ func (jm *Controller) manageJob(activePods []*v1.Pod, succeeded int32, job *batc
 			for i := int32(0); i < batchSize; i++ {
 				go func() {
 					defer wait.Done()
-					err := jm.podControl.CreatePodsWithControllerRef(job.Namespace, &job.Spec.Template, job, metav1.NewControllerRef(job, controllerKind))
+					err := jm.podControl.CreatePodsWithControllerRef(context.Background(), job.Namespace, &job.Spec.Template, job, metav1.NewControllerRef(job, controllerKind))
 					if err != nil {
 						if errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
 							// If the namespace is being torn down, we can safely ignore

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -541,7 +541,7 @@ func (rsc *ReplicaSetController) processNextWorkItem() bool {
 // It will requeue the replica set in case of an error while creating/deleting pods.
 func (rsc *ReplicaSetController) manageReplicas(filteredPods []*v1.Pod, rs *apps.ReplicaSet) error {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), rs.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), rs)
 
 	diff := len(filteredPods) - int(*(rs.Spec.Replicas))
 	rsKey, err := controller.KeyFunc(rs)
@@ -717,7 +717,7 @@ func (rsc *ReplicaSetController) syncReplicaSet(key string) error {
 
 func (rsc *ReplicaSetController) claimPods(rs *apps.ReplicaSet, selector labels.Selector, filteredPods []*v1.Pod) ([]*v1.Pod, error) {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), rs.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), rs)
 
 	// If any adoptions are attempted, we should first recheck for deletion with
 	// an uncached quorum read sometime after listing Pods (see #42639).

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -37,7 +37,7 @@ import (
 	"time"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +60,7 @@ import (
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/util/httptrace"
 	"k8s.io/utils/integer"
 )
 
@@ -539,6 +540,9 @@ func (rsc *ReplicaSetController) processNextWorkItem() bool {
 // Does NOT modify <filteredPods>.
 // It will requeue the replica set in case of an error while creating/deleting pods.
 func (rsc *ReplicaSetController) manageReplicas(filteredPods []*v1.Pod, rs *apps.ReplicaSet) error {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), rs.GetAnnotations())
+
 	diff := len(filteredPods) - int(*(rs.Spec.Replicas))
 	rsKey, err := controller.KeyFunc(rs)
 	if err != nil {
@@ -566,7 +570,8 @@ func (rsc *ReplicaSetController) manageReplicas(filteredPods []*v1.Pod, rs *apps
 		// after one of its pods fails.  Conveniently, this also prevents the
 		// event spam that those failures would generate.
 		successfulCreations, err := slowStartBatch(diff, controller.SlowStartInitialBatchSize, func() error {
-			err := rsc.podControl.CreatePodsWithControllerRef(rs.Namespace, &rs.Spec.Template, rs, metav1.NewControllerRef(rs, rsc.GroupVersionKind))
+
+			err = rsc.podControl.CreatePodsWithControllerRef(ctx, rs.Namespace, &rs.Spec.Template, rs, metav1.NewControllerRef(rs, rsc.GroupVersionKind))
 			if err != nil {
 				if errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
 					// if the namespace is being terminated, we don't have to do
@@ -711,10 +716,13 @@ func (rsc *ReplicaSetController) syncReplicaSet(key string) error {
 }
 
 func (rsc *ReplicaSetController) claimPods(rs *apps.ReplicaSet, selector labels.Selector, filteredPods []*v1.Pod) ([]*v1.Pod, error) {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), rs.GetAnnotations())
+
 	// If any adoptions are attempted, we should first recheck for deletion with
 	// an uncached quorum read sometime after listing Pods (see #42639).
 	canAdoptFunc := controller.RecheckDeletionTimestamp(func() (metav1.Object, error) {
-		fresh, err := rsc.kubeClient.AppsV1().ReplicaSets(rs.Namespace).Get(context.TODO(), rs.Name, metav1.GetOptions{})
+		fresh, err := rsc.kubeClient.AppsV1().ReplicaSets(rs.Namespace).Get(ctx, rs.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -29,7 +29,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -333,12 +333,12 @@ func (pc podControlAdapter) CreatePodsOnNode(nodeName, namespace string, templat
 	return errors.New("CreatePodsOnNode() is not implemented for podControlAdapter")
 }
 
-func (pc podControlAdapter) CreatePodsWithControllerRef(namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
+func (pc podControlAdapter) CreatePodsWithControllerRef(ctx context.Context, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
 	rc, err := convertRStoRC(object.(*apps.ReplicaSet))
 	if err != nil {
 		return err
 	}
-	return pc.PodControlInterface.CreatePodsWithControllerRef(namespace, template, rc, controllerRef)
+	return pc.PodControlInterface.CreatePodsWithControllerRef(ctx, namespace, template, rc, controllerRef)
 }
 
 func (pc podControlAdapter) DeletePod(namespace string, podID string, object runtime.Object) error {

--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -75,7 +75,7 @@ type realStatefulPodControl struct {
 
 func (spc *realStatefulPodControl) CreateStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), set.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), set)
 
 	// Create the Pod's PVCs prior to creating the Pod
 	if err := spc.createPersistentVolumeClaims(set, pod); err != nil {
@@ -95,7 +95,7 @@ func (spc *realStatefulPodControl) CreateStatefulPod(set *apps.StatefulSet, pod 
 
 func (spc *realStatefulPodControl) UpdateStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), set.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), set)
 
 	attemptedUpdate := false
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -145,7 +145,7 @@ func (spc *realStatefulPodControl) UpdateStatefulPod(set *apps.StatefulSet, pod 
 
 func (spc *realStatefulPodControl) DeleteStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), set.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), set)
 
 	err := spc.client.CoreV1().Pods(set.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 	spc.recordPodEvent("delete", set, pod, err)
@@ -191,7 +191,7 @@ func (spc *realStatefulPodControl) recordClaimEvent(verb string, set *apps.State
 // set's Spec.
 func (spc *realStatefulPodControl) createPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
 	// Get span from annotations and set to ctx
-	ctx := httptrace.SpanContextFromAnnotations(context.Background(), set.GetAnnotations())
+	ctx := httptrace.SpanContextWithObject(context.Background(), set)
 
 	var errs []error
 	for _, claim := range getPersistentVolumeClaims(set, pod) {

--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
@@ -32,6 +32,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/pkg/util/httptrace"
 )
 
 // StatefulPodControlInterface defines the interface that StatefulSetController uses to create, update, and delete Pods,
@@ -73,13 +74,17 @@ type realStatefulPodControl struct {
 }
 
 func (spc *realStatefulPodControl) CreateStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), set.GetAnnotations())
+
 	// Create the Pod's PVCs prior to creating the Pod
 	if err := spc.createPersistentVolumeClaims(set, pod); err != nil {
 		spc.recordPodEvent("create", set, pod, err)
 		return err
 	}
 	// If we created the PVCs attempt to create the Pod
-	_, err := spc.client.CoreV1().Pods(set.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+
+	_, err := spc.client.CoreV1().Pods(set.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 	// sink already exists errors
 	if apierrors.IsAlreadyExists(err) {
 		return err
@@ -89,6 +94,9 @@ func (spc *realStatefulPodControl) CreateStatefulPod(set *apps.StatefulSet, pod 
 }
 
 func (spc *realStatefulPodControl) UpdateStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), set.GetAnnotations())
+
 	attemptedUpdate := false
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		// assume the Pod is consistent
@@ -115,7 +123,7 @@ func (spc *realStatefulPodControl) UpdateStatefulPod(set *apps.StatefulSet, pod 
 
 		attemptedUpdate = true
 		// commit the update, retrying on conflicts
-		_, updateErr := spc.client.CoreV1().Pods(set.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+		_, updateErr := spc.client.CoreV1().Pods(set.Namespace).Update(ctx, pod, metav1.UpdateOptions{})
 		if updateErr == nil {
 			return nil
 		}
@@ -136,7 +144,10 @@ func (spc *realStatefulPodControl) UpdateStatefulPod(set *apps.StatefulSet, pod 
 }
 
 func (spc *realStatefulPodControl) DeleteStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
-	err := spc.client.CoreV1().Pods(set.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), set.GetAnnotations())
+
+	err := spc.client.CoreV1().Pods(set.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 	spc.recordPodEvent("delete", set, pod, err)
 	return err
 }
@@ -179,12 +190,15 @@ func (spc *realStatefulPodControl) recordClaimEvent(verb string, set *apps.State
 // may be called again until no error is returned, indicating the PersistentVolumeClaims for pod are consistent with
 // set's Spec.
 func (spc *realStatefulPodControl) createPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
+	// Get span from annotations and set to ctx
+	ctx := httptrace.SpanContextFromAnnotations(context.Background(), set.GetAnnotations())
+
 	var errs []error
 	for _, claim := range getPersistentVolumeClaims(set, pod) {
 		pvc, err := spc.pvcLister.PersistentVolumeClaims(claim.Namespace).Get(claim.Name)
 		switch {
 		case apierrors.IsNotFound(err):
-			_, err := spc.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(context.TODO(), &claim, metav1.CreateOptions{})
+			_, err := spc.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(ctx, &claim, metav1.CreateOptions{})
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to create PVC %s: %s", claim.Name, err))
 			}

--- a/pkg/util/httptrace/httptrace.go
+++ b/pkg/util/httptrace/httptrace.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel"
 	apitrace "go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
-	"go.opentelemetry.io/otel/propagators"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type contextKeyType int
@@ -37,6 +37,11 @@ const initialTraceIDAnnotationKey string = "trace.kubernetes.io.initial"
 const spanContextAnnotationKey string = "trace.kubernetes.io.span.context"
 
 const initialTraceIDBaggageKey label.Key = "Initial-Trace-Id"
+
+// SpanContextWithObject returns a context.Context with Spacn and Baggage from the passed object
+func SpanContextWithObject(ctx context.Context, meta metav1.Object) context.Context {
+	return SpanContextFromAnnotations(ctx, meta.GetAnnotations())
+}
 
 // SpanContextFromAnnotations get span context from annotations
 func SpanContextFromAnnotations(ctx context.Context, annotations map[string]string) context.Context {

--- a/pkg/util/httptrace/httptrace.go
+++ b/pkg/util/httptrace/httptrace.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httptrace
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+
+	"go.opentelemetry.io/otel"
+	apitrace "go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/label"
+	"go.opentelemetry.io/otel/propagators"
+)
+
+type contextKeyType int
+
+// avoid use char `/` in string
+const initialTraceIDAnnotationKey string = "trace.kubernetes.io.initial"
+
+// avoid use char `/` in string
+const spanContextAnnotationKey string = "trace.kubernetes.io.span.context"
+
+const initialTraceIDBaggageKey label.Key = "Initial-Trace-Id"
+
+// SpanContextFromAnnotations get span context from annotations
+func SpanContextFromAnnotations(ctx context.Context, annotations map[string]string) context.Context {
+	// get init trace id from annotations
+	ctx = otel.ContextWithBaggageValues(
+		ctx,
+		label.KeyValue{
+			Key:   initialTraceIDBaggageKey,
+			Value: label.StringValue(annotations[initialTraceIDAnnotationKey]),
+		},
+	)
+	// get span context from annotations
+	spanContext, err := decodeSpanContext(annotations[spanContextAnnotationKey])
+	if err != nil {
+		return ctx
+	}
+	span := httpTraceSpan{
+		spanContext: spanContext,
+	}
+	return apitrace.ContextWithSpan(ctx, span)
+}
+
+// decodeSpanContext decode encodedSpanContext to spanContext
+func decodeSpanContext(encodedSpanContext string) (apitrace.SpanContext, error) {
+	// decode to byte
+	byteList := make([]byte, base64.StdEncoding.DecodedLen(len(encodedSpanContext)))
+	l, err := base64.StdEncoding.Decode(byteList, []byte(encodedSpanContext))
+	if err != nil {
+		return apitrace.EmptySpanContext(), err
+	}
+	byteList = byteList[:l]
+	// decode to span context
+	buffer := bytes.NewBuffer(byteList)
+	spanContext := apitrace.SpanContext{}
+	err = binary.Read(buffer, binary.LittleEndian, &spanContext)
+	if err != nil {
+		return apitrace.EmptySpanContext(), err
+	}
+	return spanContext, nil
+}

--- a/pkg/util/httptrace/httptrace_test.go
+++ b/pkg/util/httptrace/httptrace_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httptrace

--- a/pkg/util/httptrace/httptrace_type.go
+++ b/pkg/util/httptrace/httptrace_type.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httptrace
+
+import (
+	"context"
+	"time"
+
+	apitrace "go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/label"
+)
+
+type httpTraceSpan struct {
+	spanContext apitrace.SpanContext
+}
+
+// Tracer returns tracer used to create this span. Tracer cannot be nil.
+func (span httpTraceSpan) Tracer() apitrace.Tracer {
+	return nil
+}
+
+// End completes the span. No updates are allowed to span after it
+// ends. The only exception is setting status of the span.
+func (span httpTraceSpan) End(options ...apitrace.SpanOption) {
+	return
+}
+
+// AddEvent adds an event to the span.
+func (span httpTraceSpan) AddEvent(ctx context.Context, name string, attrs ...label.KeyValue) {
+	return
+}
+
+// AddEventWithTimestamp adds an event with a custom timestamp
+// to the span.
+func (span httpTraceSpan) AddEventWithTimestamp(ctx context.Context, timestamp time.Time, name string, attrs ...label.KeyValue) {
+	return
+}
+
+// IsRecording returns true if the span is active and recording events is enabled.
+func (span httpTraceSpan) IsRecording() bool {
+	return false
+}
+
+// RecordError records an error as a span event.
+func (span httpTraceSpan) RecordError(ctx context.Context, err error, opts ...apitrace.ErrorOption) {
+	return
+}
+
+// SpanContext returns span context of the span. Returned SpanContext is usable
+// even after the span ends.
+func (span httpTraceSpan) SpanContext() apitrace.SpanContext {
+	return span.spanContext
+}
+
+// SetStatus sets the status of the span in the form of a code
+// and a message.  SetStatus overrides the value of previous
+// calls to SetStatus on the Span.
+//
+// The default span status is OK, so it is not necessary to
+// explicitly set an OK status on successful Spans unless it
+// is to add an OK message or to override a previous status on the Span.
+func (span httpTraceSpan) SetStatus(code codes.Code, msg string) {
+	return
+}
+
+// SetName sets the name of the span.
+func (span httpTraceSpan) SetName(name string) {
+	return
+}
+
+// SetAttributes set span attributes
+func (span httpTraceSpan) SetAttributes(kv ...label.KeyValue) {
+	return
+}
+
+// SetAttribute set singular span attribute, with type inference.
+func (span httpTraceSpan) SetAttribute(k string, v interface{}) {
+	return
+}


### PR DESCRIPTION
rebase trace-ot to apiserver_opentelemetry

trace-ot: https://github.com/Hellcatlk/kubernetes/tree/trace-ot
apiserver-opentelemetry: https://github.com/dashpole/kubernetes/tree/apiserver_opentelemetry

start kube-apiserver with additional args: 
--feature-gates=APIServerTracing=true
--opentelemetry-config-file=/etc/kubernetes/pki/APITracing-config.yaml
```
$ cat /etc/kubernetes/pki/APITracing-config.yaml
 apiVersion: apiserver.k8s.io/v1alpha1                                           
 kind: OpenTelemetryClientConfiguration    
```

in the [webhook]( https://github.com/Hellcatlk/mutating-trace-admission-controller.git), you can get the traceid and spancontext like below:
```
[root@k8s-master mutating-trace-admission-controller]# kubectl logs trace-context-injector-webhook-deployment-64b4b8f5cc-fnbtl 
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[6454] Content-Type:[application/json] Traceparent:[00-a900e667a58c3a38c6ce4fad5bc6cfa3-ff74e238cdaa3a57-00] User-Agent:[kube-apiserver-admission]]
UPDATE
Deployment
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[4781] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-b6b1a5838f2b1d9a3229b35fa977b12f-dae8ff7033dca8db-00] User-Agent:[kube-apiserver-admission]]
UPDATE
ReplicaSet
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[2806] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-b6b1a5838f2b1d9a3229b35fa977b12f-1efa853c20836245-00] User-Agent:[kube-apiserver-admission]]
CREATE
Pod
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[3153] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-a900e667a58c3a38c6ce4fad5bc6cfa3-a3c51fd003a223ef-00] User-Agent:[kube-apiserver-admission]]
CREATE
ReplicaSet
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[2806] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-a900e667a58c3a38c6ce4fad5bc6cfa3-c79f261ecf9d4757-00] User-Agent:[kube-apiserver-admission]]
CREATE
Pod
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[4781] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-b6b1a5838f2b1d9a3229b35fa977b12f-257b4ca2c78f74a8-00] User-Agent:[kube-apiserver-admission]]
UPDATE
ReplicaSet
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[4781] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-b6b1a5838f2b1d9a3229b35fa977b12f-ff49918d4d89c810-00] User-Agent:[kube-apiserver-admission]]
UPDATE
ReplicaSet
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[4781] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-b6b1a5838f2b1d9a3229b35fa977b12f-1d6836517fcb8860-00] User-Agent:[kube-apiserver-admission]]
UPDATE
ReplicaSet
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[4781] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-a900e667a58c3a38c6ce4fad5bc6cfa3-339d90c85b4bbf14-00] User-Agent:[kube-apiserver-admission]]
UPDATE
ReplicaSet
-------------------------------------
-------------------------------------
map[Accept:[application/json, */*] Accept-Encoding:[gzip] Content-Length:[2806] Content-Type:[application/json] Otcorrelations:[Initial-Trace-Id=60889a79-62fe-47ff-a051-c98a46cb72fe] Traceparent:[00-a900e667a58c3a38c6ce4fad5bc6cfa3-47aa1de685bb3781-00] User-Agent:[kube-apiserver-admission]]
CREATE
Pod
-------------------------------------
```

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
